### PR TITLE
Update to Python 3 and support multiple changelog entries

### DIFF
--- a/obs-service-update_changelog.spec
+++ b/obs-service-update_changelog.spec
@@ -1,24 +1,23 @@
 # spec file for package obs-service-update_changelog
 
-%{?!python_module:%define python_module() python-%{**} python3-%{**}}
 %define service update_changelog
 %define branch master
 
 Name:           obs-service-%{service}
-Version:        0.5.8
+Version:        0.6.0
 Release:        0
 Summary:        An OBS source service: Update spec file version
 License:        GPL-2.0+
 Group:          Development/Tools/Building
-Url:            https://github.com/dincamihai/obs-service-%{service}/archive/%{branch}.tar.gz
-Source:         https://github.com/dincamihai/obs-service-%{service}/archive/%{branch}.tar.gz
+Url:            https://github.com/openSUSE/obs-service-%{service}/archive/%{branch}.tar.gz
+Source:         https://github.com/openSUSE/obs-service-%{service}/archive/%{branch}.tar.gz
 BuildArch:      noarch
-BuildRequires:  %{python_module devel}
+BuildRequires:  python3-devel
 BuildRequires:  python-rpm-macros
-Requires:       python-GitPython
-Requires:       python-Jinja2 >= 2.9
-Requires:       python-py
-Requires:       python-pytz
+Requires:       python3-GitPython
+Requires:       python3-Jinja2 >= 2.9
+Requires:       python3-py
+Requires:       python3-pytz
 BuildRoot:      %{_tmppath}/%{name}-%{branch}
 
 %description
@@ -37,12 +36,10 @@ Service to update the changelog from git commits.
 %makeinstall
 
 %files
-/usr/lib/obs
-/usr/lib/obs/service
+%dir /usr/lib/obs
+%dir /usr/lib/obs/service
 /usr/bin/update_changelog
-%{python_sitelib}/updatechangelog
 %{python3_sitelib}/updatechangelog
-%{python_sitelib}/updatechangelog-*.egg-info
 %{python3_sitelib}/updatechangelog-*.egg-info
 /usr/lib/obs/service/update_changelog
 /usr/lib/obs/service/update_changelog.service

--- a/tests/expected.output
+++ b/tests/expected.output
@@ -1,7 +1,4 @@
--------------------------------------------------------------------
-Wed Mar 21 17:35:34 UTC 2018 - Fake Name <fake@example.com>
-                                                                                    
-- First entry
+First entry
 - Second entry
 
 - Added:

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -9,10 +9,13 @@ from updatechangelog import common
 def test_nothing_new():
     os_mock = Mock()
     os_mock.getcwd.return_value = ''
-    mock_Repo = MagicMock()
-    with patch.multiple(common, os=os_mock, Repo=mock_Repo):
-        with pytest.raises(SystemExit, match=r'0'):
-            common.main()
+    Repo_mock = MagicMock()
+    write_mock = Mock()
+    open_mock = MagicMock()
+    open_mock.write = write_mock
+    with patch.multiple(common, os=os_mock, Repo=Repo_mock, open=open_mock):
+        common.main()
+    assert write_mock.called_once()
 
 
 def test_rendering():
@@ -46,32 +49,35 @@ def test_rendering():
     assert changelog_entry == expected
 
 
-@pytest.mark.skip
 def test_new_commit():
     os_mock = Mock()
     os_mock.getcwd.return_value = ''
-    mock_Repo = MagicMock()
+    Repo_mock = MagicMock()
+    write_mock = Mock()
+    open_mock = MagicMock()
+    open_mock.write = write_mock
 
-    mock_commit1 = MagicMock()
-    mock_commit1.configure_mock(
+    commit1_mock = MagicMock()
+    commit1_mock.configure_mock(
         hexsha = 'abcdef12345'
     )
-    mock_commit1.tree.side_effect = [
+    commit1_mock.tree.side_effect = [
         {'salt': [Mock(path='existing.patch')]},
     ]
 
-    mock_commit2 = MagicMock()
-    mock_commit2.configure_mock(
+    commit2_mock = MagicMock()
+    commit2_mock.configure_mock(
         hexsha = 'abcdef12345'
     )
-    mock_commit2.tree.side_effect = [
+    commit2_mock.tree.side_effect = [
         {'salt': [Mock(path='current.patch')]},
     ]
 
-    mock_Repo.return_value.commit.side_effects = [
-        mock_commit1,
-        mock_commit2
+    Repo_mock.return_value.commit.side_effects = [
+        commit1_mock,
+        commit2_mock
     ]
-    with patch.multiple(common, os=os_mock, Repo=mock_Repo):
-        with pytest.raises(SystemExit, match=r'0'):
-            common.main()
+
+    with patch.multiple(common, os=os_mock, Repo=Repo_mock, open=open_mock):
+        common.main()
+    assert write_mock.called_once()

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -36,16 +36,13 @@ def test_rendering():
 
     changelog_entry = template.render(
         messages=messages,
-        name=name,
-        email=email,
         added=added,
         modified=modified,
         deleted=deleted,
-        datetime='Wed Mar 21 17:35:34 UTC 2018'
-    )
+    ).strip()
     expected = ''
     with open('tests/expected.output', 'r') as f:
-        expected = f.read()
+        expected = f.read().strip()
     assert changelog_entry == expected
 
 

--- a/update_changelog
+++ b/update_changelog
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+#!/usr/bin/python3
 from updatechangelog.common import main
 
 

--- a/updatechangelog/common.py
+++ b/updatechangelog/common.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import sys
 import os
 import py
@@ -87,8 +86,8 @@ def main():
     messages = []
     while ref.hexsha != repo.commit(lastrevision).hexsha:
         if "[skip]" not in ref.message:
-            messages.append(ref.message.encode('utf8'))
-        ref = repo.commit("%s^" % ref.hexsha)
+            messages.append(ref.message)
+        ref = repo.commit(f"{ref.hexsha}^")
 
     if not messages:
         log.info("Nothing new.")
@@ -98,7 +97,7 @@ def main():
             added=added,
             modified=modified,
             deleted=deleted,
-        ).encode("utf-8").strip()
+        ).strip()
 
         cmd = "mailaddr={0} {1} -m {2}".format(cmd_quote(commit.author.email),
                                                OSC_VC,
@@ -106,7 +105,7 @@ def main():
         os.system(cmd)
 
     try:
-        with open('_lastrevision', 'wb') as f:
+        with open('_lastrevision', 'w') as f:
             f.write(commit.hexsha)
     except Exception as exc:
         log.error("Unable to update _lastrevision file: {}".format(exc))

--- a/updatechangelog/common.py
+++ b/updatechangelog/common.py
@@ -85,8 +85,9 @@ def main():
     ref = repo.commit("HEAD")
     messages = []
     while ref.hexsha != repo.commit(lastrevision).hexsha:
-        if "[skip]" not in ref.message:
-            messages.append(ref.message)
+        for line in ref.message.split('\n'):
+            if "[skip]" not in line and line:
+                messages.append(line)
         ref = repo.commit(f"{ref.hexsha}^")
 
     if not messages:

--- a/updatechangelog/templates/header.txt
+++ b/updatechangelog/templates/header.txt
@@ -1,9 +1,10 @@
 {%- if messages -%}
 {%- for item in messages -%}
+{#- osc vc adds one "-" #}
 {% if loop.index != 1 %}- {% endif %}{{ item | safe }}
 {%- endfor %}
 {%- if added -%}
-{{- "\n" -}}
+{{- "\n" }}
 - Added:
   {%- for item in added %}
   * {{ item }}


### PR DESCRIPTION
Python 2 is not supported anymore and this service is built for Leaps and TW which all have Python >= 3.6. 

This PR also changes the generation of the changelog entries, it appends "-" to each line of the commit message. Multiple entries don't require manually adding "-" anymore, but a single multi-line changelog entry needs to be manually adapted. The common usecase is to have one changelog entry per line in the commit message, so this change should make the process easier overall.