### PR TITLE
Sort mentioned patches based on their commit time

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,29 @@
+name: 'Run unit tests'
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  run-unit-tests:
+    name: Run unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Salt
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytz gitpython mock pytest jinja2
+      - name: Run unit tests
+        run: |
+          pytest tests -vvv

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,13 @@
 from distutils.core import setup
 
 setup(
-    name='updatechangelog',
+    name="updatechangelog",
     include_package_data=True,
-    package_data = {
-        'updatechangelog': ['templates/*']
-    },
-    install_requires=['jinja2', 'py', 'gitpython', 'pytz'],
-    version='0.1',
-    packages=['updatechangelog'],
-    license='MIT',
-    scripts=['update_changelog'],
-    description='OBS service to update changelog'
+    package_data={"updatechangelog": ["templates/*"]},
+    install_requires=["jinja2", "py", "gitpython", "pytz"],
+    version="0.1",
+    packages=["updatechangelog"],
+    license="MIT",
+    scripts=["update_changelog"],
+    description="OBS service to update changelog",
 )

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -1,7 +1,7 @@
 import pytz
 import pytest
 from datetime import datetime
-from mock import Mock, MagicMock, patch
+from mock import Mock, MagicMock, patch, mock_open
 
 from updatechangelog import common
 
@@ -10,12 +10,10 @@ def test_nothing_new():
     os_mock = Mock()
     os_mock.getcwd.return_value = ""
     Repo_mock = MagicMock()
-    write_mock = Mock()
-    open_mock = MagicMock()
-    open_mock.write = write_mock
+    open_mock = mock_open()
     with patch.multiple(common, os=os_mock, Repo=Repo_mock, open=open_mock):
         common.main()
-    assert write_mock.called_once()
+    open_mock().write.assert_called_once()
 
 
 def test_rendering():
@@ -44,9 +42,7 @@ def test_new_commit():
     os_mock = Mock()
     os_mock.getcwd.return_value = ""
     Repo_mock = MagicMock()
-    write_mock = Mock()
-    open_mock = MagicMock()
-    open_mock.write = write_mock
+    open_mock = mock_open()
 
     commit1_mock = MagicMock()
     commit1_mock.configure_mock(hexsha="abcdef12345")
@@ -64,4 +60,4 @@ def test_new_commit():
 
     with patch.multiple(common, os=os_mock, Repo=Repo_mock, open=open_mock):
         common.main()
-    assert write_mock.called_once()
+    open_mock().write.assert_called_once()

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -8,7 +8,7 @@ from updatechangelog import common
 
 def test_nothing_new():
     os_mock = Mock()
-    os_mock.getcwd.return_value = ''
+    os_mock.getcwd.return_value = ""
     Repo_mock = MagicMock()
     write_mock = Mock()
     open_mock = MagicMock()
@@ -21,20 +21,11 @@ def test_nothing_new():
 def test_rendering():
     template = common.get_template()
     messages = ["First entry", "Second entry"]
-    name = 'Fake Name'
-    email = 'fake@example.com'
-    added = [
-        'first_added.patch',
-        'second_added.patch'
-    ]
-    modified = [
-        'first_modified.patch',
-        'second_modified.patch'
-    ]
-    deleted = [
-        'first_deleted.patch',
-        'second_deleted.patch'
-    ]
+    name = "Fake Name"
+    email = "fake@example.com"
+    added = ["first_added.patch", "second_added.patch"]
+    modified = ["first_modified.patch", "second_modified.patch"]
+    deleted = ["first_deleted.patch", "second_deleted.patch"]
     current_dt = datetime.now().replace(tzinfo=pytz.utc)
 
     changelog_entry = template.render(
@@ -43,40 +34,33 @@ def test_rendering():
         modified=modified,
         deleted=deleted,
     ).strip()
-    expected = ''
-    with open('tests/expected.output', 'r') as f:
+    expected = ""
+    with open("tests/expected.output", "r") as f:
         expected = f.read().strip()
     assert changelog_entry == expected
 
 
 def test_new_commit():
     os_mock = Mock()
-    os_mock.getcwd.return_value = ''
+    os_mock.getcwd.return_value = ""
     Repo_mock = MagicMock()
     write_mock = Mock()
     open_mock = MagicMock()
     open_mock.write = write_mock
 
     commit1_mock = MagicMock()
-    commit1_mock.configure_mock(
-        hexsha = 'abcdef12345'
-    )
+    commit1_mock.configure_mock(hexsha="abcdef12345")
     commit1_mock.tree.side_effect = [
-        {'salt': [Mock(path='existing.patch')]},
+        {"salt": [Mock(path="existing.patch")]},
     ]
 
     commit2_mock = MagicMock()
-    commit2_mock.configure_mock(
-        hexsha = 'abcdef12345'
-    )
+    commit2_mock.configure_mock(hexsha="abcdef12345")
     commit2_mock.tree.side_effect = [
-        {'salt': [Mock(path='current.patch')]},
+        {"salt": [Mock(path="current.patch")]},
     ]
 
-    Repo_mock.return_value.commit.side_effects = [
-        commit1_mock,
-        commit2_mock
-    ]
+    Repo_mock.return_value.commit.side_effects = [commit1_mock, commit2_mock]
 
     with patch.multiple(common, os=os_mock, Repo=Repo_mock, open=open_mock):
         common.main()

--- a/updatechangelog/common.py
+++ b/updatechangelog/common.py
@@ -13,7 +13,7 @@ except ImportError:
     from pipes import quote as cmd_quote
 
 
-OSC_VC = '/usr/lib/build/vc'
+OSC_VC = "/usr/lib/build/vc"
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -24,37 +24,41 @@ log.addHandler(ch)
 
 def get_template():
     env = Environment(
-        loader=PackageLoader('updatechangelog', 'templates'),
-        autoescape=select_autoescape(['txt'])
+        loader=PackageLoader("updatechangelog", "templates"),
+        autoescape=select_autoescape(["txt"]),
     )
 
-    return env.get_template('header.txt')
+    return env.get_template("header.txt")
 
 
 def main():
-    repo_path = py.path.local(os.getcwd()) / 'salt-packaging'
+    repo_path = py.path.local(os.getcwd()) / "salt-packaging"
     repo = Repo(repo_path.strpath)
 
-    commit = repo.commit('HEAD')
+    commit = repo.commit("HEAD")
 
-    lastrevision = ''
-    lastrevision_file = py.path.local('_lastrevision')
+    lastrevision = ""
+    lastrevision_file = py.path.local("_lastrevision")
     if lastrevision_file.isfile():
         lastrevision = lastrevision_file.read().strip()
 
     lastrevision = lastrevision or commit.hexsha
 
     if not repo.git.merge_base(lastrevision, commit.hexsha):
-        log.error((
-            "%s is not an ancestor of %s. "
-            "Maybe force-push was used. "
-            "Fix _lastrevision reference.") % (lastrevision, commt.hexsha))
+        log.error(
+            (
+                "%s is not an ancestor of %s. "
+                "Maybe force-push was used. "
+                "Fix _lastrevision reference."
+            )
+            % (lastrevision, commt.hexsha)
+        )
         sys.exit(1)
 
     existing_patches = set(
         [
             py.path.local(it.path).basename
-            for it in repo.commit(lastrevision).tree['salt']
+            for it in repo.commit(lastrevision).tree["salt"]
             if it.path.endswith(".patch")
         ]
     )
@@ -62,7 +66,7 @@ def main():
     current_patches = set(
         [
             py.path.local(it.path).basename
-            for it in repo.commit('HEAD').tree['salt']
+            for it in repo.commit("HEAD").tree["salt"]
             if it.path.endswith(".patch")
         ]
     )
@@ -78,7 +82,9 @@ def main():
     ).difference(added.union(deleted))
 
     # Sort patches based the times of the commits
-    _sort_function = lambda x: next(repo.iter_commits(paths=os.path.join("salt", x), max_count=1)).committed_date
+    _sort_function = lambda x: next(
+        repo.iter_commits(paths=os.path.join("salt", x), max_count=1)
+    ).committed_date
     added = sorted(added, key=_sort_function, reverse=True)
     modified = sorted(modified, key=_sort_function, reverse=True)
     deleted = sorted(deleted, key=_sort_function, reverse=True)
@@ -91,7 +97,7 @@ def main():
     ref = repo.commit("HEAD")
     messages = []
     while ref.hexsha != repo.commit(lastrevision).hexsha:
-        for line in ref.message.split('\n'):
+        for line in ref.message.split("\n"):
             if "[skip]" not in line and line:
                 messages.append(line)
         ref = repo.commit(f"{ref.hexsha}^")
@@ -106,13 +112,13 @@ def main():
             deleted=deleted,
         ).strip()
 
-        cmd = "mailaddr={0} {1} -m {2}".format(cmd_quote(commit.author.email),
-                                               OSC_VC,
-                                               cmd_quote(changelog_entry))
+        cmd = "mailaddr={0} {1} -m {2}".format(
+            cmd_quote(commit.author.email), OSC_VC, cmd_quote(changelog_entry)
+        )
         os.system(cmd)
 
     try:
-        with open('_lastrevision', 'w') as f:
+        with open("_lastrevision", "w") as f:
             f.write(commit.hexsha)
     except Exception as exc:
         log.error("Unable to update _lastrevision file: {}".format(exc))

--- a/updatechangelog/common.py
+++ b/updatechangelog/common.py
@@ -77,6 +77,12 @@ def main():
         ]
     ).difference(added.union(deleted))
 
+    # Sort patches based the times of the commits
+    _sort_function = lambda x: next(repo.iter_commits(paths=os.path.join("salt", x), max_count=1)).committed_date
+    added = sorted(added, key=_sort_function, reverse=True)
+    modified = sorted(modified, key=_sort_function, reverse=True)
+    deleted = sorted(deleted, key=_sort_function, reverse=True)
+
     template = get_template()
 
     current_dt = datetime.now().replace(tzinfo=pytz.utc)


### PR DESCRIPTION
This PR makes the mentioned patches written in a generated changelog entry, to be ordered based on their commit time.

This way, the generated messages will corelate with the mentioned patches in the generated changelog entry.

Additionally, this PR is doing:
- apply black code formatting
- fix failing unit tests
- enable GitHub action to run tests for different Python version.