### PR TITLE
Always insert newline after changlog entry block

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Salt
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 #v5.5.0
         with:
           python-version: '3.x'
       - name: Display Python version

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -1,4 +1,5 @@
 import pytz
+import textwrap
 import pytest
 from datetime import datetime
 from unittest.mock import Mock, MagicMock, patch, mock_open
@@ -36,6 +37,52 @@ def test_rendering():
     with open("tests/expected.output", "r") as f:
         expected = f.read().strip()
     assert changelog_entry == expected
+
+
+def test_rendering_no_added():
+    expected_output = textwrap.dedent(
+        """
+        First entry
+        - Second entry
+
+        - Modified:
+          * first.patch
+
+        - Removed:
+          * second.patch"""
+    )
+    messages = ["First entry", "Second entry"]
+    modified = ["first.patch"]
+    deleted = ["second.patch"]
+    template = common.get_template()
+    changelog_entry = template.render(
+        messages=messages,
+        added=[],
+        modified=modified,
+        deleted=deleted,
+    )
+    assert changelog_entry == expected_output
+
+
+def test_rendering_no_added_no_modified():
+    expected_output = textwrap.dedent(
+        """
+        First entry
+        - Second entry
+
+        - Removed:
+          * first.patch"""
+    )
+    messages = ["First entry", "Second entry"]
+    deleted = ["first.patch"]
+    template = common.get_template()
+    changelog_entry = template.render(
+        messages=messages,
+        added=[],
+        modified=[],
+        deleted=deleted,
+    )
+    assert changelog_entry == expected_output
 
 
 def test_new_commit():

--- a/updatechangelog/templates/header.txt
+++ b/updatechangelog/templates/header.txt
@@ -8,17 +8,17 @@
 - Added:
   {%- for item in added %}
   * {{ item }}
-  {%- endfor %}
+  {%- endfor -%}
 {% endif %}
 {%- if modified -%}
-{{- "\n" -}}
+{{- "\n" }}
 - Modified:
   {%- for item in modified %}
   * {{ item }}
-  {%- endfor %}
+  {%- endfor -%}
 {% endif %}
 {%- if deleted -%}
-{{- "\n" -}}
+{{- "\n" }}
 - Removed:
   {%- for item in deleted %}
   * {{ item }}


### PR DESCRIPTION
Previously, only a newline was entered if new patches were added.

Also pin GH Actions to commits.